### PR TITLE
APPSEC-3214: Upgrade git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,11 +374,11 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -576,9 +576,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.15.1+1.6.4"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ strip = "debuginfo"
 base64 = "0.21.0"
 clap = { version = "4.4.18", features = ["derive"] }
 colored = "2.1.0"
-git2 = "0.17.1"
+git2 = "0.18.2"
 jsonwebtoken = "8.3.0"
 openssl = { version = "0.10.60", features = ["vendored"] }
 once_cell = "1.17.1"


### PR DESCRIPTION
## Context

- [GitHub Advisory: libgit2-sys affected by memory corruption, denial of service, and arbitrary code execution in libgit2](https://github.com/advisories/GHSA-22q8-ghmq-63vf)